### PR TITLE
Support golang 1.11 modules

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -25,10 +25,12 @@ generate_pipeline() {
     local target_version_prop="${target}_VERSION"
     local target_goos_prop="${target}_GOOS"
     local target_goarch_prop="${target}_GOARCH"
+    local target_modules_prop="${target}_MODULES"
 
     local target_version=${!target_version_prop}
     local target_goos=${!target_goos_prop:-}
     local target_goarch=${!target_goarch_prop:-}
+    local target_modules=${!target_modules_prop:-}
 
     if is_debug ; then
       echo "Found target $target $target_version $target_goos $target_goarch" >&2
@@ -40,6 +42,10 @@ generate_pipeline() {
 
     if [[ "$target_goos" == "windows" ]]; then
       artifact_path+=".exe"
+    fi
+
+    if [[ -n "$target_modules" ]] ; then
+      env+=("GO111MODULE=${target_modules}")
     fi
 
     local build_args=("-v" "-o" "'${artifact_path}'")


### PR DESCRIPTION
This supports golang 1.11 modules, which require code to either be outside of a gopath, or set `GO111MODULE=on`.

See https://github.com/golang/go/wiki/Modules#installing-and-activating-module-support for more details.

An example would be:

```yaml
steps:
  - plugins:
      golang-cross-compile#v1.0.0:
        build: main.go
        import: github.com/buildkite/example
        targets:
          - version: 1.11
            goos: linux
            goarch: amd64
            modules: "on"
```