### PR TITLE
Fix go version may be passed to the go-buildkite-plugin as a number and not a string

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         debug: true
         build: ./tests/helloworld
-        import: github.com/buildkite/example
+        import: github.com/buildkite-plugins/golang-cross-compile-buildkite-plugin
         targets:
           - version: "1.20"
             goos: linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,16 +23,12 @@ steps:
         build: ./tests/helloworld
         import: github.com/buildkite/example
         targets:
-          - version: 1.10.2
+          - version: "1.20"
             goos: linux
             goarch: amd64
-          - version: 1.10.2
+          - version: "1.20"
             goos: windows
             goarch: amd64
-          - version: 1.10.2
+          - version: "1.20"
             goos: darwin
             goarch: amd64
-
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/buildkite-plugins/golang-cross-compile-buildkite-plugin
+
+go 1.20

--- a/hooks/command
+++ b/hooks/command
@@ -63,7 +63,7 @@ generate_pipeline() {
     plugins:
       golang#${GOLANG_PLUGIN_VERSION}:
         import: ${import}
-        version: ${target_version}
+        version: "${target_version}"
         environment:
 YAML
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -28,7 +28,7 @@ steps:
     plugins:
       golang#v2.0.0:
         import: buildkite.com/buildkite/agent
-        version: 1.10.1
+        version: "1.10.1"
         environment:
           - GOOS=linux
           - GOARCH=amd64
@@ -39,7 +39,7 @@ steps:
     plugins:
       golang#v2.0.0:
         import: buildkite.com/buildkite/agent
-        version: 1.10.2
+        version: "1.10.2"
         environment:
           - GOOS=darwin
           - GOARCH=386
@@ -78,7 +78,7 @@ steps:
     plugins:
       golang#v2.0.0:
         import: buildkite.com/buildkite/agent
-        version: 1.10.1
+        version: "1.10.1"
         environment:
           - GOOS=windows
           - GOARCH=amd64
@@ -118,7 +118,7 @@ steps:
     plugins:
       golang#v2.0.0:
         import: buildkite.com/buildkite/agent
-        version: 1.10.1
+        version: "1.10.1"
         environment:
           - GOOS=linux
           - GOARCH=amd64
@@ -159,7 +159,7 @@ steps:
     plugins:
       golang#v2.0.0:
         import: buildkite.com/buildkite/agent
-        version: 1.10.1
+        version: "1.10.1"
         environment:
           - GOOS=linux
           - GOARCH=amd64


### PR DESCRIPTION
This means that when trying to specify the go version with `"1.20"`, the current version of go, `1.2` is passed to the golang-buildkite-plugin instead. Note that even if the user is doing the right thing and quotes the version in their pipeline, but this plugin does not respect that.

Fortunately, specifying the version as `1.20.0` side steps the issue, as there is a tag on the docker image for both 1.20 and 1.20.0. However, we should support both ways to specify the version, as much of the [release materials](https://go.dev/doc/devel/release) refer to it as 1.20 and not 1.20.0. As a further example, the URL to download the source is https://go.dev/dl/go1.20.src.tar.gz, whereas https://go.dev/dl/go1.20.0.src.tar.gz is a 404.